### PR TITLE
Tweaks for client/server and fxmanifest

### DIFF
--- a/config.lua
+++ b/config.lua
@@ -1,5 +1,5 @@
 Config = {}
-Config.Locale = 'fr'
+Config.Locale = 'en'
 
 Config.Accounts = {
 	bank = _U('account_bank'),
@@ -16,6 +16,5 @@ Config.EnablePvP            = true -- enable pvp?
 Config.MaxWeight            = 24   -- the max inventory weight without backpack
 
 Config.PaycheckInterval     = 7 * 60000 -- how often to recieve pay checks in milliseconds
-Config.CoordsSyncInterval   = 2 * 60000 -- how often to sync coords with server in milliseconds
 
 Config.EnableDebug          = false

--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -102,3 +102,5 @@ dependencies {
 	'mysql-async',
 	'async'
 }
+
+provide 'es_extended'

--- a/server/classes/player.lua
+++ b/server/classes/player.lua
@@ -321,7 +321,7 @@ function CreateExtendedPlayer(playerId, identifier, group, accounts, inventory, 
 			TriggerEvent('esx:setJob', self.source, self.job, lastJob)
 			self.triggerEvent('esx:setJob', self.job)
 		else
-			print(('[es_extended] [^3WARNING^7] Ignoring invalid .setJob() usage for "%s"'):format(self.identifier))
+			print(('[ExtendedMode] [^3WARNING^7] Ignoring invalid .setJob() usage for "%s"'):format(self.identifier))
 		end
 	end
 

--- a/server/common.lua
+++ b/server/common.lua
@@ -41,26 +41,26 @@ MySQL.ready(function()
 				if ESX.Jobs[v.job_name] then
 					ESX.Jobs[v.job_name].grades[tostring(v.grade)] = v
 				else
-					print(('[es_extended] [^3WARNING^7] Ignoring job grades for "%s" due to missing job'):format(v.job_name))
+					print(('[ExtendedMode] [^3WARNING^7] Ignoring job grades for "%s" due to missing job'):format(v.job_name))
 				end
 			end
 
 			for k2,v2 in pairs(ESX.Jobs) do
 				if ESX.Table.SizeOf(v2.grades) == 0 then
 					ESX.Jobs[v2.name] = nil
-					print(('[es_extended] [^3WARNING^7] Ignoring job "%s" due to no job grades found'):format(v2.name))
+					print(('[ExtendedMode] [^3WARNING^7] Ignoring job "%s" due to no job grades found'):format(v2.name))
 				end
 			end
 		end)
 	end)
 
-	print('[es_extended] [^2INFO^7] ESX developed by ESX-Org has been initialized')
+	print('[ExtendedMode] [^2INFO^7] ExM developed by the community for the community!')
 end)
 
 RegisterServerEvent('esx:clientLog')
 AddEventHandler('esx:clientLog', function(msg)
 	if Config.EnableDebug then
-		print(('[es_extended] [^2TRACE^7] %s^7'):format(msg))
+		print(('[ExtendedMode] [^2TRACE^7] %s^7'):format(msg))
 	end
 end)
 

--- a/server/functions.lua
+++ b/server/functions.lua
@@ -1,6 +1,6 @@
 ESX.Trace = function(msg)
 	if Config.EnableDebug then
-		print(('[es_extended] [^2TRACE^7] %s^7'):format(msg))
+		print(('[ExtendedMode] [^2TRACE^7] %s^7'):format(msg))
 	end
 end
 
@@ -30,7 +30,7 @@ ESX.RegisterCommand = function(name, group, cb, allowConsole, suggestion)
 	end
 
 	if ESX.RegisteredCommands[name] then
-		print(('[es_extended] [^3WARNING^7] An command "%s" is already registered, overriding command'):format(name))
+		print(('[ExtendedMode] [^3WARNING^7] An command "%s" is already registered, overriding command'):format(name))
 
 		if ESX.RegisteredCommands[name].suggestion then
 			TriggerClientEvent('chat:removeSuggestion', -1, ('/%s'):format(name))
@@ -50,7 +50,7 @@ ESX.RegisterCommand = function(name, group, cb, allowConsole, suggestion)
 		local command = ESX.RegisteredCommands[name]
 
 		if not command.allowConsole and playerId == 0 then
-			print(('[es_extended] [^3WARNING^7] %s'):format(_U('commanderror_console')))
+			print(('[ExtendedMode] [^3WARNING^7] %s'):format(_U('commanderror_console')))
 		else
 			local xPlayer, error = ESX.GetPlayerFromId(playerId), nil
 
@@ -122,14 +122,14 @@ ESX.RegisterCommand = function(name, group, cb, allowConsole, suggestion)
 
 			if error then
 				if playerId == 0 then
-					print(('[es_extended] [^3WARNING^7] %s^7'):format(error))
+					print(('[ExtendedMode] [^3WARNING^7] %s^7'):format(error))
 				else
 					xPlayer.triggerEvent('chat:addMessage', {args = {'^1SYSTEM', error}})
 				end
 			else
 				cb(xPlayer or false, args, function(msg)
 					if playerId == 0 then
-						print(('[es_extended] [^3WARNING^7] %s^7'):format(msg))
+						print(('[ExtendedMode] [^3WARNING^7] %s^7'):format(msg))
 					else
 						xPlayer.triggerEvent('chat:addMessage', {args = {'^1SYSTEM', msg}})
 					end
@@ -159,7 +159,7 @@ ESX.TriggerServerCallback = function(name, requestId, source, cb, ...)
 	if ESX.ServerCallbacks[name] then
 		ESX.ServerCallbacks[name](source, cb, ...)
 	else
-		print(('[es_extended] [^3WARNING^7] Server callback "%s" does not exist. Make sure that the server sided file really is loading, an error in that file might cause it to not load.'):format(name))
+		print(('[ExtendedMode] [^3WARNING^7] Server callback "%s" does not exist. Make sure that the server sided file really is loading, an error in that file might cause it to not load.'):format(name))
 	end
 end
 
@@ -182,7 +182,7 @@ ESX.SavePlayer = function(xPlayer, cb)
 	end)
 
 	Async.parallel(asyncTasks, function(results)
-		print(('[es_extended] [^2INFO^7] Saved player "%s^7"'):format(xPlayer.getName()))
+		print(('[ExtendedMode] [^2INFO^7] Saved player "%s^7"'):format(xPlayer.getName()))
 
 		if cb then
 			cb()
@@ -201,7 +201,7 @@ ESX.SavePlayers = function(cb)
 	end
 
 	Async.parallelLimit(asyncTasks, 8, function(results)
-		print(('[es_extended] [^2INFO^7] Saved %s player(s)'):format(#xPlayers))
+		print(('[ExtendedMode] [^2INFO^7] Saved %s player(s)'):format(#xPlayers))
 		if cb then
 			cb()
 		end

--- a/server/main.lua
+++ b/server/main.lua
@@ -109,7 +109,7 @@ function loadESXPlayer(identifier, playerId)
 			if ESX.DoesJobExist(job, grade) then
 				jobObject, gradeObject = ESX.Jobs[job], ESX.Jobs[job].grades[grade]
 			else
-				print(('[es_extended] [^3WARNING^7] Ignoring invalid job for %s [job: %s, grade: %s]'):format(identifier, job, grade))
+				print(('[ExtendedMode] [^3WARNING^7] Ignoring invalid job for %s [job: %s, grade: %s]'):format(identifier, job, grade))
 				job, grade = 'unemployed', '0'
 				jobObject, gradeObject = ESX.Jobs[job], ESX.Jobs[job].grades[grade]
 			end
@@ -139,7 +139,7 @@ function loadESXPlayer(identifier, playerId)
 					if item then
 						foundItems[name] = count
 					else
-						print(('[es_extended] [^3WARNING^7] Ignoring invalid item "%s" for "%s"'):format(name, identifier))
+						print(('[ExtendedMode] [^3WARNING^7] Ignoring invalid item "%s" for "%s"'):format(name, identifier))
 					end
 				end
 			end
@@ -196,7 +196,7 @@ function loadESXPlayer(identifier, playerId)
 			if result[1].position and result[1].position ~= '' then
 				userData.coords = json.decode(result[1].position)
 			else
-				print('[es_extended] [^3WARNING^7] Column "position" in "users" table is missing required default value. Using backup coords, fix your database.')
+				print('[ExtendedMode] [^3WARNING^7] Column "position" in "users" table is missing required default value. Using backup coords, fix your database.')
 				userData.coords = {x = -269.4, y = -955.3, z = 31.2, heading = 205.8}
 			end
 


### PR DESCRIPTION
CLIENT;
- Removed a bunch more GetHashKey calls
- Removed PlayerPedId() being stored in a variable when only being called once
- Simplified the teleport function but removing where it was adding 0.0 to the numbers to make them a float when we force a vector now and it does it for us
- Made pickups have no collisions
- Simplified the updating coords function
- Simplified the picking up of pickups by removing the closestDistance check since it's not needed
- Set the default language to English in the config
- Removed the CoordsSyncInterval from the config, since it was unneeded

SERVER;
- Replaced "es_extended"  in prints with "ExtendedMode"

FXMANIFEST;
- Updated fxmanifest.lua to have "es_extended" as a provide meaning resources that have "es_extended" as a dependency will use ExtendedMode instead. (Apparently this was already the case in the main branch, for some reason it was lacking in my fork, this conflict has been resolved in latest commit added to this PR Request)