### PR TITLE
Server and Client tweaks

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -65,7 +65,7 @@ AddEventHandler('esx:playerLoaded', function(playerData)
 		z = playerData.coords.z + 0.5,
 		heading = playerData.coords.heading
 	}, function()
-		isLoadoutLoaded, isDead = true, false
+		isLoadoutLoaded = true
 		TriggerServerEvent('esx:onPlayerSpawn')
 		TriggerEvent('esx:onPlayerSpawn')
 		TriggerEvent('playerSpawned') -- compatibility with old scripts, will be removed soon
@@ -80,6 +80,7 @@ end)
 RegisterNetEvent('esx:setMaxWeight')
 AddEventHandler('esx:setMaxWeight', function(newMaxWeight) ESX.PlayerData.maxWeight = newMaxWeight end)
 
+AddEventHandler('esx:onPlayerSpawn', function() isDead = false end)
 AddEventHandler('esx:onPlayerDeath', function() isDead = true end)
 AddEventHandler('skinchanger:loadDefaultModel', function() isLoadoutLoaded = false end)
 
@@ -99,21 +100,20 @@ AddEventHandler('esx:restoreLoadout', function()
 
 	for k,v in ipairs(ESX.PlayerData.loadout) do
 		local weaponName = v.name
-		local weaponHash = GetHashKey(weaponName)
 
-		GiveWeaponToPed(playerPed, weaponHash, 0, false, false)
-		SetPedWeaponTintIndex(playerPed, weaponHash, v.tintIndex)
+		GiveWeaponToPed(playerPed, weaponName, 0, false, false)
+		SetPedWeaponTintIndex(playerPed, weaponName, v.tintIndex)
 
-		local ammoType = GetPedAmmoTypeFromWeapon(playerPed, weaponHash)
+		local ammoType = GetPedAmmoTypeFromWeapon(playerPed, weaponName)
 
 		for k2,v2 in ipairs(v.components) do
 			local componentHash = ESX.GetWeaponComponent(weaponName, v2).hash
 
-			GiveWeaponComponentToPed(playerPed, weaponHash, componentHash)
+			GiveWeaponComponentToPed(playerPed, weaponName, componentHash)
 		end
 
 		if not ammoTypes[ammoType] then
-			AddAmmoToPed(playerPed, weaponHash, v.ammo)
+			AddAmmoToPed(playerPed, weaponName, v.ammo)
 			ammoTypes[ammoType] = true
 		end
 	end
@@ -182,59 +182,46 @@ end)
 
 RegisterNetEvent('esx:addWeapon')
 AddEventHandler('esx:addWeapon', function(weaponName, ammo)
-	local playerPed = PlayerPedId()
-
-	GiveWeaponToPed(playerPed, weaponName, ammo, false, false)
+	-- Removed PlayerPedId() from being stored in a variable, not needed
+	-- when it's only being used once, also doing it in a few
+	-- functions below this one
+	GiveWeaponToPed(PlayerPedId(), weaponName, ammo, false, false)
 end)
 
 RegisterNetEvent('esx:addWeaponComponent')
 AddEventHandler('esx:addWeaponComponent', function(weaponName, weaponComponent)
-	local playerPed = PlayerPedId()
 	local componentHash = ESX.GetWeaponComponent(weaponName, weaponComponent).hash
-
-	GiveWeaponComponentToPed(playerPed, weaponName, componentHash)
+	GiveWeaponComponentToPed(PlayerPedId(), weaponName, componentHash)
 end)
 
 RegisterNetEvent('esx:setWeaponAmmo')
 AddEventHandler('esx:setWeaponAmmo', function(weaponName, weaponAmmo)
-	local playerPed = PlayerPedId()
-
-	SetPedAmmo(playerPed, weaponName, weaponAmmo)
+	SetPedAmmo(PlayerPedId(), weaponName, weaponAmmo)
 end)
 
 RegisterNetEvent('esx:setWeaponTint')
 AddEventHandler('esx:setWeaponTint', function(weaponName, weaponTintIndex)
-	local playerPed = PlayerPedId()
-
-	SetPedWeaponTintIndex(playerPed, weaponName, weaponTintIndex)
+	SetPedWeaponTintIndex(PlayerPedId(), weaponName, weaponTintIndex)
 end)
 
 RegisterNetEvent('esx:removeWeapon')
 AddEventHandler('esx:removeWeapon', function(weaponName)
 	local playerPed = PlayerPedId()
-
 	RemoveWeaponFromPed(playerPed, weaponName)
 	SetPedAmmo(playerPed, weaponName, 0) -- remove leftover ammo
 end)
 
 RegisterNetEvent('esx:removeWeaponComponent')
 AddEventHandler('esx:removeWeaponComponent', function(weaponName, weaponComponent)
-	local playerPed = PlayerPedId()
 	local componentHash = ESX.GetWeaponComponent(weaponName, weaponComponent).hash
-
-	RemoveWeaponComponentFromPed(playerPed, weaponName, componentHash)
+	RemoveWeaponComponentFromPed(PlayerPedId(), weaponName, componentHash)
 end)
 
 RegisterNetEvent('esx:teleport')
 AddEventHandler('esx:teleport', function(coords)
-	local playerPed = PlayerPedId()
-
-	-- ensure decmial number
-	coords.x = coords.x + 0.0
-	coords.y = coords.y + 0.0
-	coords.z = coords.z + 0.0
-
-	ESX.Game.Teleport(playerPed, coords)
+	-- The coords x, y and z were having 0.0 added to them here to make them floats
+	-- Since we are forcing vectors in the teleport function now we don't need to do it
+	ESX.Game.Teleport(PlayerPedId(), coords)
 end)
 
 RegisterNetEvent('esx:setJob')
@@ -249,13 +236,11 @@ end)
 
 RegisterNetEvent('esx:spawnVehicle')
 AddEventHandler('esx:spawnVehicle', function(vehicle)
-	local model = (type(vehicle) == 'number' and vehicle or GetHashKey(vehicle))
-
-	if IsModelInCdimage(model) then
+	if IsModelInCdimage(vehicle) then
 		local playerPed = PlayerPedId()
 		local playerCoords, playerHeading = GetEntityCoords(playerPed), GetEntityHeading(playerPed)
 
-		ESX.Game.SpawnVehicle(model, playerCoords, playerHeading, function(vehicle)
+		ESX.Game.SpawnVehicle(vehicle, playerCoords, playerHeading, function(vehicle)
 			TaskWarpPedIntoVehicle(playerPed, vehicle, -1)
 		end)
 	else
@@ -291,6 +276,8 @@ AddEventHandler('esx:createPickup', function(pickupId, label, playerId, type, na
 	SetEntityAsMissionEntity(pickupObject, true, false)
 	PlaceObjectOnGroundProperly(pickupObject)
 	FreezeEntityPosition(pickupObject, true)
+	-- Remove the pickup collisions, also done the same in the local one below
+	SetEntityCollision(pickupObject, false, true)
 
 	pickups[pickupId] = {
 		id = pickupId,
@@ -328,6 +315,7 @@ AddEventHandler('esx:createMissingPickups', function(missingPickups)
 		SetEntityAsMissionEntity(pickupObject, true, false)
 		PlaceObjectOnGroundProperly(pickupObject)
 		FreezeEntityPosition(pickupObject, true)
+		SetEntityCollision(pickupObject, false, true)
 
 		pickups[pickupId] = {
 			id = pickupId,
@@ -473,7 +461,8 @@ CreateThread(function()
 
 				if distance < 1 then
 					if IsControlJustReleased(0, 38) then
-						if IsPedOnFoot(playerPed) and (closestDistance == -1 or closestDistance > 3) and not v.inRange then
+						-- Removed the closestDistance check here, not needed
+						if IsPedOnFoot(playerPed) and not v.inRange then
 							v.inRange = true
 
 							local dict, anim = 'weapons@first_person@aim_rng@generic@projectile@sticky_bomb@', 'plant_floor'
@@ -503,24 +492,31 @@ end)
 
 -- Update current player coords
 CreateThread(function()
-	local previousCoords = vector3(0, 0, 0)
-
 	-- wait for player to restore coords
 	while not isLoadoutLoaded do
 		Wait(1000)
 	end
+	
+	local previousCoords = vector3(ESX.PlayerData.coords.x, ESX.PlayerData.coords.y, ESX.PlayerData.coords.z)
+	local playerHeading = ESX.PlayerData.heading
+	local formattedCoords = {x = ESX.Math.Round(previousCoords.x, 1), y = ESX.Math.Round(previousCoords.y, 1), z = ESX.Math.Round(previousCoords.z, 1), heading = playerHeading}
 
 	while true do
-		Wait(Config.CoordsSyncInterval)
+		-- update the players position every second instead of a configed amount otherwise
+		-- serverside won't catch up
+		Wait(1000)
 		local playerPed = PlayerPedId()
 		local playerCoords = GetEntityCoords(playerPed)
 		local distance = #(playerCoords - previousCoords)
 
 		if distance > 10 then
 			previousCoords = playerCoords
-			local playerHeading = ESX.Math.Round(GetEntityHeading(playerPed), 1)
-			local formattedCoords = {x = ESX.Math.Round(playerCoords.x, 1), y = ESX.Math.Round(playerCoords.y, 1), z = ESX.Math.Round(playerCoords.z, 1), heading = playerHeading}
+			playerHeading = ESX.Math.Round(GetEntityHeading(playerPed), 1)
+			formattedCoords = {x = ESX.Math.Round(playerCoords.x, 1), y = ESX.Math.Round(playerCoords.y, 1), z = ESX.Math.Round(playerCoords.z, 1), heading = playerHeading}
 			TriggerServerEvent('esx:updateCoords', formattedCoords)
+			if distance > 1 then
+				TriggerServerEvent('esx:updateCoords', formattedCoords)
+			end
 		end
 	end
 end)

--- a/config.lua
+++ b/config.lua
@@ -16,6 +16,5 @@ Config.EnablePvP            = true -- enable pvp?
 Config.MaxWeight            = 24000   -- the max inventory weight without backpack(this is in grams, not kg!)
 
 Config.PaycheckInterval     = 60 * 60000 -- how often to recieve pay checks in milliseconds
-Config.CoordsSyncInterval   = 2 * 60000 -- how often to sync coords with server in milliseconds
 
 Config.EnableDebug          = false

--- a/server/classes/player.lua
+++ b/server/classes/player.lua
@@ -321,7 +321,7 @@ function CreateExtendedPlayer(playerId, identifier, group, accounts, inventory, 
 			TriggerEvent('esx:setJob', self.source, self.job, lastJob)
 			self.triggerEvent('esx:setJob', self.job)
 		else
-			print(('[es_extended] [^3WARNING^7] Ignoring invalid .setJob() usage for "%s"'):format(self.identifier))
+			print(('[ExtendedMode] [^3WARNING^7] Ignoring invalid .setJob() usage for "%s"'):format(self.identifier))
 		end
 	end
 

--- a/server/common.lua
+++ b/server/common.lua
@@ -42,26 +42,26 @@ MySQL.ready(function()
 				if ESX.Jobs[v.job_name] then
 					ESX.Jobs[v.job_name].grades[tostring(v.grade)] = v
 				else
-					print(('[es_extended] [^3WARNING^7] Ignoring job grades for "%s" due to missing job'):format(v.job_name))
+					print(('[ExtendedMode] [^3WARNING^7] Ignoring job grades for "%s" due to missing job'):format(v.job_name))
 				end
 			end
 
 			for k2,v2 in pairs(ESX.Jobs) do
 				if ESX.Table.SizeOf(v2.grades) == 0 then
 					ESX.Jobs[v2.name] = nil
-					print(('[es_extended] [^3WARNING^7] Ignoring job "%s" due to no job grades found'):format(v2.name))
+					print(('[ExtendedMode] [^3WARNING^7] Ignoring job "%s" due to no job grades found'):format(v2.name))
 				end
 			end
 		end)
 	end)
 
-	print('[es_extended] [^2INFO^7] ESX developed by ESX-Org has been initialized')
+	print('[ExtendedMode] [^2INFO^7] ESX developed by ESX-Org has been initialized')
 end)
 
 RegisterServerEvent('esx:clientLog')
 AddEventHandler('esx:clientLog', function(msg)
 	if Config.EnableDebug then
-		print(('[es_extended] [^2TRACE^7] %s^7'):format(msg))
+		print(('[ExtendedMode] [^2TRACE^7] %s^7'):format(msg))
 	end
 end)
 

--- a/server/functions.lua
+++ b/server/functions.lua
@@ -1,6 +1,6 @@
 ESX.Trace = function(msg)
 	if Config.EnableDebug then
-		print(('[es_extended] [^2TRACE^7] %s^7'):format(msg))
+		print(('[ExtendedMode] [^2TRACE^7] %s^7'):format(msg))
 	end
 end
 
@@ -30,7 +30,7 @@ ESX.RegisterCommand = function(name, group, cb, allowConsole, suggestion)
 	end
 
 	if ESX.RegisteredCommands[name] then
-		print(('[es_extended] [^3WARNING^7] An command "%s" is already registered, overriding command'):format(name))
+		print(('[ExtendedMode] [^3WARNING^7] An command "%s" is already registered, overriding command'):format(name))
 
 		if ESX.RegisteredCommands[name].suggestion then
 			TriggerClientEvent('chat:removeSuggestion', -1, ('/%s'):format(name))
@@ -50,7 +50,7 @@ ESX.RegisterCommand = function(name, group, cb, allowConsole, suggestion)
 		local command = ESX.RegisteredCommands[name]
 
 		if not command.allowConsole and playerId == 0 then
-			print(('[es_extended] [^3WARNING^7] %s'):format(_U('commanderror_console')))
+			print(('[ExtendedMode] [^3WARNING^7] %s'):format(_U('commanderror_console')))
 		else
 			local xPlayer, error = ESX.GetPlayerFromId(playerId), nil
 
@@ -122,14 +122,14 @@ ESX.RegisterCommand = function(name, group, cb, allowConsole, suggestion)
 
 			if error then
 				if playerId == 0 then
-					print(('[es_extended] [^3WARNING^7] %s^7'):format(error))
+					print(('[ExtendedMode] [^3WARNING^7] %s^7'):format(error))
 				else
 					xPlayer.triggerEvent('chat:addMessage', {args = {'^1SYSTEM', error}})
 				end
 			else
 				cb(xPlayer or false, args, function(msg)
 					if playerId == 0 then
-						print(('[es_extended] [^3WARNING^7] %s^7'):format(msg))
+						print(('[ExtendedMode] [^3WARNING^7] %s^7'):format(msg))
 					else
 						xPlayer.triggerEvent('chat:addMessage', {args = {'^1SYSTEM', msg}})
 					end
@@ -159,7 +159,7 @@ ESX.TriggerServerCallback = function(name, requestId, source, cb, ...)
 	if ESX.ServerCallbacks[name] then
 		ESX.ServerCallbacks[name](source, cb, ...)
 	else
-		print(('[es_extended] [^3WARNING^7] Server callback "%s" does not exist. Make sure that the server sided file really is loading, an error in that file might cause it to not load.'):format(name))
+		print(('[ExtendedMode] [^3WARNING^7] Server callback "%s" does not exist. Make sure that the server sided file really is loading, an error in that file might cause it to not load.'):format(name))
 	end
 end
 
@@ -182,7 +182,7 @@ ESX.SavePlayer = function(xPlayer, cb)
 	end)
 
 	Async.parallel(asyncTasks, function(results)
-		print(('[es_extended] [^2INFO^7] Saved player "%s^7"'):format(xPlayer.getName()))
+		print(('[ExtendedMode] [^2INFO^7] Saved player "%s^7"'):format(xPlayer.getName()))
 
 		if cb then
 			cb()
@@ -201,7 +201,7 @@ ESX.SavePlayers = function(cb)
 	end
 
 	Async.parallelLimit(asyncTasks, 8, function(results)
-		print(('[es_extended] [^2INFO^7] Saved %s player(s)'):format(#xPlayers))
+		print(('[ExtendedMode] [^2INFO^7] Saved %s player(s)'):format(#xPlayers))
 		if cb then
 			cb()
 		end

--- a/server/main.lua
+++ b/server/main.lua
@@ -113,7 +113,7 @@ function loadESXPlayer(identifier, playerId)
 			if ESX.DoesJobExist(job, grade) then
 				jobObject, gradeObject = ESX.Jobs[job], ESX.Jobs[job].grades[grade]
 			else
-				print(('[es_extended] [^3WARNING^7] Ignoring invalid job for %s [job: %s, grade: %s]'):format(identifier, job, grade))
+				print(('[ExtendedMode] [^3WARNING^7] Ignoring invalid job for %s [job: %s, grade: %s]'):format(identifier, job, grade))
 				job, grade = 'unemployed', '0'
 				jobObject, gradeObject = ESX.Jobs[job], ESX.Jobs[job].grades[grade]
 			end
@@ -143,7 +143,7 @@ function loadESXPlayer(identifier, playerId)
 					if item then
 						foundItems[name] = count
 					else
-						print(('[es_extended] [^3WARNING^7] Ignoring invalid item "%s" for "%s"'):format(name, identifier))
+						print(('[ExtendedMode] [^3WARNING^7] Ignoring invalid item "%s" for "%s"'):format(name, identifier))
 					end
 				end
 			end
@@ -201,7 +201,7 @@ function loadESXPlayer(identifier, playerId)
 			if result[1].position and result[1].position ~= '' then
 				userData.coords = json.decode(result[1].position)
 			else
-				print('[es_extended] [^3WARNING^7] Column "position" in "users" table is missing required default value. Using backup coords, fix your database.')
+				print('[ExtendedMode] [^3WARNING^7] Column "position" in "users" table is missing required default value. Using backup coords, fix your database.')
 				userData.coords = {x = -269.4, y = -955.3, z = 31.2, heading = 205.8}
 			end
 


### PR DESCRIPTION
Client;
- Removed a bunch more GetHashKey calls
- Removed PlayerPedId() being stored in a variable when only being called once
- Simplified the teleport function but removing where it was adding 0.0 to the numbers to make them a float when we force a vector now and it does it for us
- Made pickups have no collisions
- Simplified the updating coords function
- Simplified the picking up of pickups by removing the closestDistance check since it's not needed
- Removed the CoordsSyncInterval from the config, since it was unneeded

Server;
- Replaced "es_extended" in prints with "ExtendedMode"