### PR TITLE
feature: add ExM shared object and import script

### DIFF
--- a/client/common.lua
+++ b/client/common.lua
@@ -2,6 +2,10 @@ AddEventHandler('esx:getSharedObject', function(cb)
 	cb(ESX)
 end)
 
-function getSharedObject()
+exports("getSharedObject", function()
 	return ESX
-end
+end)
+
+exports("getExtendedModeObject", function()
+	return ExM
+end)

--- a/client/functions.lua
+++ b/client/functions.lua
@@ -1,24 +1,42 @@
-ESX                           = {}
-ESX.PlayerData                = {}
-ESX.PlayerLoaded              = false
-ESX.CurrentRequestId          = 0
-ESX.ServerCallbacks           = {}
-ESX.TimeoutCallbacks          = {}
+ESX = {}
+ESX.PlayerData = {}
+ESX.PlayerLoaded = false
+ESX.CurrentRequestId = 0
+ESX.ServerCallbacks = {}
+ESX.TimeoutCallbacks = {}
 
-ESX.UI                        = {}
-ESX.UI.HUD                    = {}
+ESX.UI = {}
+ESX.UI.HUD = {}
 ESX.UI.HUD.RegisteredElements = {}
-ESX.UI.Menu                   = {}
-ESX.UI.Menu.RegisteredTypes   = {}
-ESX.UI.Menu.Opened            = {}
+ESX.UI.Menu = {}
+ESX.UI.Menu.RegisteredTypes = {}
+ESX.UI.Menu.Opened = {}
 
-ESX.Game                      = {}
-ESX.Game.Utils                = {}
+ESX.Game = {}
+ESX.Game.Utils = {}
 
-ESX.Scaleform                 = {}
-ESX.Scaleform.Utils           = {}
+ESX.Scaleform = {}
+ESX.Scaleform.Utils = {}
 
-ESX.Streaming                 = {}
+ESX.Streaming = {}
+
+-- Add a seperate table for ExtendedMode functions, but using metatables to limit feature usage on the ESX table
+-- This is to provide backward compatablity with ESX but not add new features to the old ESX tables.
+-- Note: Please add all new namespaces to ExM _after_ this block
+do
+    local function processTable(thisTable)
+        local thisObject = setmetatable({}, {
+            __index = thisTable
+        })
+        for key, value in pairs(thisTable) do
+            if type(value) == "table" then
+                thisObject[key] = processTable(value)
+            end
+        end
+        return thisObject
+    end
+    ExM = processTable(ESX)
+end
 
 ESX.SetTimeout = function(msec, cb)
 	table.insert(ESX.TimeoutCallbacks, {

--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -84,7 +84,9 @@ files {
 
 	'html/img/accounts/bank.png',
 	'html/img/accounts/black_money.png',
-	'html/img/accounts/money.png'
+	'html/img/accounts/money.png',
+
+	'imports.lua'
 }
 
 exports {

--- a/imports.lua
+++ b/imports.lua
@@ -1,0 +1,52 @@
+-- Import the ESX and ExM objects then patch ExM with metatables
+-- The metatables are not shared across exports sadly, we have to do that ourselves
+if exports and exports["extendedmode"] then
+	-- Get the base ESX shared object and the ExM shared object acts as overrides for the ExM object we are about to create
+	local ESX = exports["extendedmode"]:getSharedObject()
+	local ExM_overrides = exports["extendedmode"]:getExtendedModeObject()
+
+	do -- Keep in a seperate block to not override anything in the script
+		local function addMetatables(thisTable)
+			-- Create a table and set its metatable to the table we were passed
+			local thisObject = setmetatable({}, {
+				__index = thisTable
+			})
+
+			-- Check if the table we were passed has any more tables within it 
+			for key, value in pairs(thisTable) do
+				if type(value) == "table" and not value.__cfx_functionReference then
+					-- if so, call this function again but passing it the table we found
+					-- then set the return of that function call to the same key in our new object
+					thisObject[key] = addMetatables(value)
+				end
+			end
+
+			-- Finally, return our object to whatever called it
+			return thisObject
+		end
+
+		-- Start the process of creating the ExM object through traversing the ESX namespaces
+		ExM = addMetatables(ESX)
+	end
+
+	do
+		local function copyTableToTable(table1, table2)
+			-- Search through table1
+			for key, value in pairs(table1) do
+				if type(value) == "table" and not value.__cfx_functionReference then
+					-- If this value is a table, make sure table2 has a corresponding table at this key then call this function again on the two tables
+					if not rawget(table2, key) then table2[key] = {} end
+					copyTableToTable(value, table2[key])
+				else
+					-- If this value is anything else, copy it to table2
+					table2[key] = value
+				end
+			end
+		end
+
+		-- Start overriding our own ExM object with all the global ExM object stuff...
+		copyTableToTable(ExM_overrides, ExM)
+	end
+
+	-- By this point, everything should be ready and ExM should be setup with the appropriate metatables
+end

--- a/server/common.lua
+++ b/server/common.lua
@@ -10,13 +10,35 @@ ESX.PickupId = 0
 ESX.Jobs = {}
 ESX.RegisteredCommands = {}
 
+-- Add a seperate table for ExtendedMode functions, but using metatables to limit feature usage on the ESX table
+-- This is to provide backward compatablity with ESX but not add new features to the old ESX tables.
+-- Note: Please add all new namespaces to ExM _after_ this block
+do
+    local function processTable(thisTable)
+        local thisObject = setmetatable({}, {
+            __index = thisTable
+        })
+        for key, value in pairs(thisTable) do
+            if type(value) == "table" then
+                thisObject[key] = processTable(value)
+            end
+        end
+        return thisObject
+    end
+    ExM = processTable(ESX)
+end
+
 AddEventHandler('esx:getSharedObject', function(cb)
 	cb(ESX)
 end)
 
-function getSharedObject()
+exports("getSharedObject", function()
 	return ESX
-end
+end)
+
+exports("getExtendedModeObject", function()
+	return ExM
+end)
 
 MySQL.ready(function()
 	MySQL.Async.fetchAll('SELECT * FROM items', {}, function(result)


### PR DESCRIPTION
- Add the ExM shared object
This acts as a mirror to the old ESX object through the use of metatables however, allows the ExM object to override the ESX object without effecting any backwards compatibility and doesn't allow access to new ExM functions from the ESX object.

- Add imports.lua
This is the way to access the new ExM shared object in resources. Simply import this file within your resource's fxmanifest (`shared_script "@extendedmode/imports.lua"`) and the `ExM` object will be present.