### PR TITLE
tweak (client) / fxmanifest changes

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -15,24 +15,9 @@ RegisterNetEvent('esx:playerLoaded')
 AddEventHandler('esx:playerLoaded', function(playerData)
 	ESX.PlayerLoaded = true
 	ESX.PlayerData = playerData
-
-	-- check if player is coming from loading screen
-	if GetEntityModel(PlayerPedId()) == `PLAYER_ZERO` then
-		local defaultModel = `a_m_y_stbla_02`
-		
-		RequestModel(defaultModel)
-		while not HasModelLoaded(defaultModel) do
-			Wait(0)
-		end
-
-		SetPlayerModel(PlayerId(), defaultModel)
-		local playerPed = PlayerPedId()
-
-		SetPedDefaultComponentVariation(playerPed)
-		SetPedRandomComponentVariation(playerPed, true)
-		SetModelAsNoLongerNeeded(defaultModel)
-		FreezeEntityPosition(playerPed, false)
-	end
+	
+	-- Removed some unnecessary statement here checking if you were Michael, it did nothing really.
+	-- Was also kind of broken because anyone who has a SP save no using Michael wouldn't even get it.
 
 	local playerPed = PlayerPedId()
 
@@ -59,21 +44,18 @@ AddEventHandler('esx:playerLoaded', function(playerData)
 		})
 	end
 
-	ESX.Game.Teleport(playerPed, {
+	-- Using spawnmanager now to spawn the player, this is the right way to do it, and it transitions better.
+	exports.spawnmanager:spawnPlayer({
 		x = playerData.coords.x,
 		y = playerData.coords.y,
-		z = playerData.coords.z + 0.5,
-		heading = playerData.coords.heading
+		z = playerData.coords.z,
+		heading = playerData.coords.heading,
+		skipFade = false
 	}, function()
 		isLoadoutLoaded = true
 		TriggerServerEvent('esx:onPlayerSpawn')
 		TriggerEvent('esx:onPlayerSpawn')
-		TriggerEvent('playerSpawned') -- compatibility with old scripts, will be removed soon
 		TriggerEvent('esx:restoreLoadout')
-
-		Wait(3000)
-		ShutdownLoadingScreen()
-		DoScreenFadeIn(10000)
 	end)
 end)
 

--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -1,23 +1,16 @@
-fx_version 'adamant'
+fx_version 'bodacious'
 game 'gta5'
 description 'extendedmode'
 version '0.0.1'
+
+resource_type 'gametype' { name = 'extendedmode' }
 
 server_scripts {
 	'@async/async.lua',
 	'@mysql-async/lib/MySQL.lua',
 
 	'locale.lua',
-	'locales/de.lua',
-	'locales/br.lua',
-	'locales/fr.lua',
-	'locales/en.lua',
-	'locales/fi.lua',
-	'locales/sv.lua',
-	'locales/pl.lua',
-	'locales/cs.lua',
-	'locales/sc.lua',
-	'locales/tc.lua',
+	'locales/*.lua',
 
 	'config.lua',
 	'config.weapons.lua',
@@ -36,16 +29,7 @@ server_scripts {
 
 client_scripts {
 	'locale.lua',
-	'locales/de.lua',
-	'locales/br.lua',
-	'locales/fr.lua',
-	'locales/en.lua',
-	'locales/fi.lua',
-	'locales/sv.lua',
-	'locales/pl.lua',
-	'locales/cs.lua',
-	'locales/sc.lua',
-	'locales/tc.lua',
+	'locales/*.lua',
 
 	'config.lua',
 	'config.weapons.lua',


### PR DESCRIPTION
- Updated fx_version to `bodacious`
- Made locales a wildcard (neater)
- Made extendedmode a gametype now, this enables spawnmanager to work better, this also fixed the player not returning to their saved spawn point on first join
- Removed an broken statement from `client/main.lua`
- Now using spawnmanager when spawning the ped, much better to use