### PR TITLE
refactor: drop async library in favor of mysql transactions

### DIFF
--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -6,7 +6,6 @@ version '0.0.1'
 resource_type 'gametype' { name = 'extendedmode' }
 
 server_scripts {
-	'@async/async.lua',
 	'@mysql-async/lib/MySQL.lua',
 
 	'locale.lua',
@@ -83,7 +82,6 @@ server_exports {
 
 dependencies {
 	'mysql-async',
-	'async'
 }
 
 provide 'es_extended'

--- a/server/common.lua
+++ b/server/common.lua
@@ -77,7 +77,7 @@ MySQL.ready(function()
 		end)
 	end)
 
-	print('[ExtendedMode] [^2INFO^7] ESX developed by ESX-Org has been initialized')
+	print('[ExtendedMode] [^2INFO^7] ExtendedMode has been initialized')
 end)
 
 RegisterServerEvent('esx:clientLog')


### PR DESCRIPTION
### Drop the (useless) async library from extendedmode's dependencies.
async was used to *supposedly* parallelise the saving and loading tasks however, as lua *threads* on FXServer are just lua coroutines, there is no parallelism taking place. 

### Replace async lib calls with MySQL transactions.
MySQL transactions are now being used, saving players should be much faster and more reliable.

### Remove ESX-Org branding from startup message.