### PR TITLE
Pull changes from dev into master

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # extendedmode
-extendedmode is a community edition fork of es_extended and will be maintained by various trusted members of the fivem community.
+extendedmode is a community edition fork of es_extended (better known as ESX) and will be maintained by various trusted members of the FiveM community.
 
 ## Primary goals for this project
 - Allow even versions of ESX scripts pre 1.2 to continue to function with as few edits as possible.
@@ -12,6 +12,8 @@ ESX was initially developed by Gizz back in 2017 for his friend as the were crea
 
 ## Links & Read more
 
+- [FiveM Forum Thread]() (coming soon!)
+- [ESX Migration Guide]() (coming soon!)
 - [FiveM Native Reference](https://runtime.fivem.net/doc/reference.html)
 
 ## Features
@@ -25,63 +27,72 @@ ESX was initially developed by Gizz back in 2017 for his friend as the were crea
 - Easy to use API for developers to easily integrate EX to their projects
 - Register your own commands easily, with argument validation, chat suggestion and using FXServer ACL
 
-## Extendedmode Exclusive Features
+## extendedmode Exclusive Features
 
-We have made some exclusive features for extendedmode only, find them all here; [Functions](FUNCTIONS.md)
+We have made some exclusive features for extendedmode only, find them all here: [Functions](FUNCTIONS.md)
 
 ## Requirements
 
-- [mysql-async](https://github.com/brouznouf/fivem-mysql-async)
-- [async](https://github.com/ESX-Org/async)
+- A fully configured installation of [mysql-async](https://github.com/brouznouf/fivem-mysql-async) (or equivalent)
 
-### Using Git
+## Using
 
-- cd resources
-- git clone https://github.com/extendedmode/extendedmode extendedmode
-- git clone https://github.com/ESX-Org/esx_menu_default [ex]/[ui]/esx_menu_default
-- git clone https://github.com/ESX-Org/esx_menu_dialog [ex]/[ui]/esx_menu_dialog
-- git clone https://github.com/ESX-Org/esx_menu_list [ex]/[ui]/esx_menu_list
+Be warned that extendedmode is in ALPHA stages and is **not** ready for production use.
 
-### Manually
+If you already have an ESX installation please see [this]() guide! (coming soon!)
 
-- Download https://github.com/extendedmode/extendedmode/releases/latest
-- Put it in the `resource/[extended]` directory
-- Download https://github.com/ESX-Org/esx_menu_default/releases/latest
-- Put it in the `resource/[ex]/[ui]` directory
-- Download https://github.com/ESX-Org/esx_menu_dialog/releases/latest
-- Put it in the `resource/[ex]/[ui]` directory
-- Download https://github.com/ESX-Org/esx_menu_list/releases/latest
-- Put it in the `resource/[ex]/[ui]` directory
+### Downloading
+
+While it is recommended that you organise your resources into sub directories, FXServer allows you to place resources anywhere in the `resources` provided that you do not place them within other resources or directories with names not surrounded by `[]`.
+
+#### Using Git
+
+- `cd resources`
+- `git clone https://github.com/extendedmode/extendedmode extendedmode`
+- `git clone https://github.com/ESX-Org/esx_menu_default esx_menu_default`
+- `git clone https://github.com/ESX-Org/esx_menu_dialog esx_menu_dialog`
+- `git clone https://github.com/ESX-Org/esx_menu_list esx_menu_list`
+
+#### Manually
+
+- Download [extendedmode](https://github.com/extendedmode/extendedmode/releases/latest) into the `resources` directory
+- Download [esx_menu_default](https://github.com/ESX-Org/esx_menu_default/releases/latest) into the `resources` directory
+- Download [esx_menu_dialog](https://github.com/ESX-Org/esx_menu_dialog/releases/latest) into the `resources` directory
+- Download [esx_menu_list](https://github.com/ESX-Org/esx_menu_list/releases/latest) into the `resources` directory
 
 ### Installation
 
-- Import `extendedmode.sql` in your database
-- Configure your `server.cfg` to look like this
+- Import `extendedmode.sql` in an SQL database
+- Configure your `server.cfg` like the example below
 
 ```
+# The included fivem resource needs to be disabled at the moment due to a known issue with mapmanager, this will be fixed soon
+#ensure fivem
+
 add_principal group.admin group.user
 add_ace resource.extendedmode command.add_ace allow
 add_ace resource.extendedmode command.add_principal allow
 add_ace resource.extendedmode command.remove_principal allow
 
-start mysql-async
-start extendedmode
+ensure mysql-async
+ensure extendedmode
 
-start esx_menu_default
-start esx_menu_list
-start esx_menu_dialog
+ensure esx_menu_default
+ensure esx_menu_list
+ensure esx_menu_dialog
 ```
+
+If all goes well, you will see the message `[ExtendedMode] [INFO] ExtendedMode has been initialized` appear in your server console without any errors.
 
 ## Legal
 
-### License
+### Licenses
 
-# extendedmode - es_extended community fork
+#### extendedmode - es_extended community fork
 
 All changes after 04/04/2020 are provided by their respective authors under the GNUGPLv3 license.
 
-# es_extended
-es_extended - EssentialMode Extended framework for FiveM
+#### es_extended - EssentialMode Extended framework for FiveM
 
 Copyright (C) 2015-2020 Jérémie N'gadi
 

--- a/README.md
+++ b/README.md
@@ -10,9 +10,15 @@ es_extended is a roleplay framework for FiveM. ESX is short for EssentialMode Ex
 
 ESX was initially developed by Gizz back in 2017 for his friend as the were creating an FiveM server and there wasn't any economy roleplaying frameworks available. The original code was written within a week or two and later open sourced, it has ever since been improved and parts been rewritten to further improve on it.
 
+## Using
+
+Be warned that extendedmode is in ALPHA stages and is **not** ready for production use.
+
+If you already have an ESX installation please see [this]() guide! (coming soon!)
+
 ## Links & Read more
 
-- [FiveM Forum Thread]() (coming soon!)
+- [Full Documentation](https://extendedmode.github.io) (Work in Progress!)
 - [ESX Migration Guide]() (coming soon!)
 - [FiveM Native Reference](https://runtime.fivem.net/doc/reference.html)
 
@@ -27,62 +33,11 @@ ESX was initially developed by Gizz back in 2017 for his friend as the were crea
 - Easy to use API for developers to easily integrate EX to their projects
 - Register your own commands easily, with argument validation, chat suggestion and using FXServer ACL
 
-## extendedmode Exclusive Features
-
-We have made some exclusive features for extendedmode only, find them all here: [Functions](FUNCTIONS.md)
+We have also made some exclusive features for extendedmode only, find them all [here](https://extendedmode.github.io/functions/Client%20Functions/)!
 
 ## Requirements
 
 - A fully configured installation of [mysql-async](https://github.com/brouznouf/fivem-mysql-async) (or equivalent)
-
-## Using
-
-Be warned that extendedmode is in ALPHA stages and is **not** ready for production use.
-
-If you already have an ESX installation please see [this]() guide! (coming soon!)
-
-### Downloading
-
-While it is recommended that you organise your resources into sub directories, FXServer allows you to place resources anywhere in the `resources` provided that you do not place them within other resources or directories with names not surrounded by `[]`.
-
-#### Using Git
-
-- `cd resources`
-- `git clone https://github.com/extendedmode/extendedmode extendedmode`
-- `git clone https://github.com/ESX-Org/esx_menu_default esx_menu_default`
-- `git clone https://github.com/ESX-Org/esx_menu_dialog esx_menu_dialog`
-- `git clone https://github.com/ESX-Org/esx_menu_list esx_menu_list`
-
-#### Manually
-
-- Download [extendedmode](https://github.com/extendedmode/extendedmode/releases/latest) into the `resources` directory
-- Download [esx_menu_default](https://github.com/ESX-Org/esx_menu_default/releases/latest) into the `resources` directory
-- Download [esx_menu_dialog](https://github.com/ESX-Org/esx_menu_dialog/releases/latest) into the `resources` directory
-- Download [esx_menu_list](https://github.com/ESX-Org/esx_menu_list/releases/latest) into the `resources` directory
-
-### Installation
-
-- Import `extendedmode.sql` in an SQL database
-- Configure your `server.cfg` like the example below
-
-```
-# The included fivem resource needs to be disabled at the moment due to a known issue with mapmanager, this will be fixed soon
-#ensure fivem
-
-add_principal group.admin group.user
-add_ace resource.extendedmode command.add_ace allow
-add_ace resource.extendedmode command.add_principal allow
-add_ace resource.extendedmode command.remove_principal allow
-
-ensure mysql-async
-ensure extendedmode
-
-ensure esx_menu_default
-ensure esx_menu_list
-ensure esx_menu_dialog
-```
-
-If all goes well, you will see the message `[ExtendedMode] [INFO] ExtendedMode has been initialized` appear in your server console without any errors.
 
 ## Legal
 

--- a/client/main.lua
+++ b/client/main.lua
@@ -60,6 +60,11 @@ AddEventHandler('esx:playerLoaded', function(playerData)
 	end)
 end)
 
+RegisterNetEvent('es:activateMoney')
+AddEventHandler('es:activateMoney', function(money)
+	ESX.PlayerData.money = money
+end)
+
 RegisterNetEvent('esx:setMaxWeight')
 AddEventHandler('esx:setMaxWeight', function(newMaxWeight) ESX.PlayerData.maxWeight = newMaxWeight end)
 

--- a/client/main.lua
+++ b/client/main.lua
@@ -50,6 +50,7 @@ AddEventHandler('esx:playerLoaded', function(playerData)
 		y = playerData.coords.y,
 		z = playerData.coords.z,
 		heading = playerData.coords.heading,
+		model = Config.DefaultPlayerModel,
 		skipFade = false
 	}, function()
 		isLoadoutLoaded = true

--- a/config.lua
+++ b/config.lua
@@ -19,3 +19,9 @@ Config.PaycheckInterval     = 60 * 60000 -- how often to recieve pay checks in m
 
 Config.EnableDebug          = false
 Config.PrimaryIdentifier	= "steam" -- Options: steam, license (social club), fivem, discord, xbl, live (default steam, recommended: fivem) this SHOULD function with most older scripts too!
+
+-- The default player model you will use if no other scripts control your player model
+-- We have set a MP ped as default since if you use another script that controls your player model
+-- then this will make them invisible until the actual outfit/model has loaded, this looks better than
+-- loading another model then changing it immediately after
+Config.DefaultPlayerModel	= `mp_m_freemode_01` 

--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -6,7 +6,6 @@ version '0.0.1'
 resource_type 'gametype' { name = 'extendedmode' }
 
 server_scripts {
-	'@async/async.lua',
 	'@mysql-async/lib/MySQL.lua',
 
 	'locale.lua',
@@ -83,7 +82,6 @@ server_exports {
 
 dependencies {
 	'mysql-async',
-	'async'
 }
 
 provide 'es_extended'

--- a/server/classes/player.lua
+++ b/server/classes/player.lua
@@ -42,21 +42,33 @@ function CreateExtendedPlayer(playerId, identifier, group, accounts, inventory, 
 		DropPlayer(self.source, reason)
 	end
 
-	self.setMoney = function(money)
+	self.setMoney = function(money, recursion)
 		money = ESX.Math.Round(money)
 		self.setAccountMoney('money', money)
+
+		if(not recursion)then
+			TriggerEvent("es:getPlayerFromId", self.source, function(user) user.setMoney(money) end)
+		end
 	end
 
 	self.getMoney = function()
 		return self.getAccount('money').money
 	end
 
-	self.addMoney = function(money)
+	self.addMoney = function(money, recursion)
 		money = ESX.Math.Round(money)
 		self.addAccountMoney('money', money)
+
+		if(not recursion)then
+			TriggerEvent("es:getPlayerFromId", self.source, function(user) user.addMoney(money, true) end)
+		end
 	end
 
-	self.removeMoney = function(money)
+	self.removeMoney = function(money, recursion)
+		if(not recursion)then
+			TriggerEvent("es:getPlayerFromId", self.source, function(user) user.removeMoney(money, true) end)
+		end
+
 		money = ESX.Math.Round(money)
 		self.removeAccountMoney('money', money)
 	end
@@ -65,7 +77,11 @@ function CreateExtendedPlayer(playerId, identifier, group, accounts, inventory, 
 		return self.identifier
 	end
 
-	self.setGroup = function(newGroup)
+	self.setGroup = function(newGroup, recursion)
+		if(not recursion)then
+			TriggerEvent("es:getPlayerFromId", self.source, function(user) user.set("group", newGroup) end)
+		end
+
 		ExecuteCommand(('remove_principal identifier.steam:%s group.%s'):format(self.identifier, self.group))
 		self.group = newGroup
 		ExecuteCommand(('add_principal identifier.steam:%s group.%s'):format(self.identifier, self.group))
@@ -75,7 +91,11 @@ function CreateExtendedPlayer(playerId, identifier, group, accounts, inventory, 
 		return self.group
 	end
 
-	self.set = function(k, v)
+	self.set = function(k, v, recursion)
+		if(not recursion)then
+			TriggerEvent("es:getPlayerFromId", self.source, function(user) user.set(k, v) end)
+		end
+
 		self.variables[k] = v
 	end
 

--- a/server/commands.lua
+++ b/server/commands.lua
@@ -130,11 +130,25 @@ end, true, {help = _U('command_setgroup'), validate = true, arguments = {
 }})
 
 ESX.RegisterCommand('save', 'admin', function(xPlayer, args, showError)
-	ESX.SavePlayer(args.playerId)
+	print(('[ExtendedMode] [^2INFO^7] Manual player data save triggered for "%s"'):format(args.playerId.name))
+	ESX.SavePlayer(args.playerId, function(rowsChanged)
+		if rowsChanged ~= 0 then
+			print(('[ExtendedMode] [^2INFO^7] Saved player data for "%s"'):format(args.playerId.name))
+		else
+			print(('[ExtendedMode] [^3WARNING^7] Failed to save player data for "%s"! This may be caused by an internal error on the MySQL server.'):format(args.playerId.name))
+		end
+	end)
 end, true, {help = _U('command_save'), validate = true, arguments = {
 	{name = 'playerId', help = _U('commandgeneric_playerid'), type = 'player'}
 }})
 
 ESX.RegisterCommand('saveall', 'admin', function(xPlayer, args, showError)
-	ESX.SavePlayers()
+	print('[ExtendedMode] [^2INFO^7] Manual player data save triggered')
+	ESX.SavePlayers(function(result)
+		if result then
+			print('[ExtendedMode] [^2INFO^7] Saved all player data')
+		else
+			print('[ExtendedMode] [^3WARNING^7] Failed to save player data! This may be caused by an internal error on the MySQL server.')
+		end
+	end)
 end, true, {help = _U('command_saveall')})

--- a/server/common.lua
+++ b/server/common.lua
@@ -77,7 +77,7 @@ MySQL.ready(function()
 		end)
 	end)
 
-	print('[ExtendedMode] [^2INFO^7] ESX developed by ESX-Org has been initialized')
+	print('[ExtendedMode] [^2INFO^7] ExtendedMode has been initialized')
 end)
 
 RegisterServerEvent('esx:clientLog')

--- a/server/functions.lua
+++ b/server/functions.lua
@@ -209,7 +209,13 @@ end
 
 ESX.StartDBSync = function()
 	function saveData()
-		ESX.SavePlayers()
+		ESX.SavePlayers(function(result)
+			if result then
+				print('[ExtendedMode] [^2INFO^7] Automatically saved all player data')
+			else
+				print('[ExtendedMode] [^3WARNING^7] Failed to automatically save player data! This may be caused by an internal error on the MySQL server.')
+			end
+		end)
 		SetTimeout(10 * 60 * 1000, saveData)
 	end
 

--- a/server/main.lua
+++ b/server/main.lua
@@ -499,5 +499,34 @@ ESX.RegisterServerCallback('esx:getPlayerNames', function(source, cb, players)
 	cb(players)
 end)
 
+-- Add support for EssentialMode >6.4.x
+AddEventHandler("es:setMoney", function(user, value) ESX.GetPlayerFromId(user).setMoney(value, true) end)
+AddEventHandler("es:addMoney", function(user, value) ESX.GetPlayerFromId(user).addMoney(value, true) end)
+AddEventHandler("es:removeMoney", function(user, value) ESX.GetPlayerFromId(user).removeMoney(value, true) end)
+AddEventHandler("es:set", function(user, key, value) ESX.GetPlayerFromId(user).set(key, value, true) end)
+
+AddEventHandler("es_db:doesUserExist", function(identifier, cb)
+	cb(true)
+end)
+
+AddEventHandler('es_db:retrieveUser', function(identifier, cb, tries)
+	tries = tries or 0
+
+	if(tries < 500)then
+		tries = tries + 1
+		local player = ESX.GetPlayerFromIdentifier(identifier)
+
+		if player then
+			print("Returning user: " .. player.identifier)
+			cb({permission_level = 0, money = player.getMoney(), bank = 0, identifier = player.identifier, license = player.get("license"), group = player.group, roles = ""}, false, true)
+		else
+			print("Try: " .. tostring(tries))
+			Citizen.SetTimeout(100, function()
+				TriggerEvent("es_db:retrieveUser", identifier, cb, tries)
+			end)
+		end
+	end
+end)
+
 ESX.StartDBSync()
 ESX.StartPayCheck()

--- a/server/main.lua
+++ b/server/main.lua
@@ -517,10 +517,8 @@ AddEventHandler('es_db:retrieveUser', function(identifier, cb, tries)
 		local player = ESX.GetPlayerFromIdentifier(identifier)
 
 		if player then
-			print("Returning user: " .. player.identifier)
 			cb({permission_level = 0, money = player.getMoney(), bank = 0, identifier = player.identifier, license = player.get("license"), group = player.group, roles = ""}, false, true)
 		else
-			print("Try: " .. tostring(tries))
 			Citizen.SetTimeout(100, function()
 				TriggerEvent("es_db:retrieveUser", identifier, cb, tries)
 			end)


### PR DESCRIPTION
# Notable Changes

### Updates to README.md
The readme has been somewhat rewritten with the bulk of it removed and transferred to the new docs website, currently hosted using GitHub pages at [extendedmode.github.io](https://extendedmode.github.io/) although, the location and host is subject to change.

### Addition of a default player model config option
The option `Config.DefaultPlayerModel` now allows configuration of the model used to spawn the player using [spawnmanager].

### Dropping [async] as a dependency.
[async] was used to *supposedly* speed up saving and loading tasks on the server using parallelisation however, [async] does its *parallelisation* with *threads* using `Citizen.CreateThread`. `CreateThread` is just a managed alias for Lua's `coroutine` library and as such, is only single threaded resulting in **worse** performance due to [async]'s overhead. 

### Refactor of player saving to utilise MySQL transactions.
To make saving all players on the server more reliable, the player saving code now uses MySQL transactions.

It may be a good idea to wait for for @blattersturm to update [dblyr] and fix its transaction support before merging, [dblyr] can then be recommended over [mysql-async] for new installations. [mysql-async] currently works with extendedmode's transaction implementation.

### Support for EssentialMode addons
extendemode now supports [EssentialMode] thanks to @kanersps!
Related PR: #35 

[async]: https://github.com/ESX-Org/async
[mysql-async]: https://github.com/brouznouf/fivem-mysql-async
[dblyr]: https://github.com/blattersturm/dblyr
[spawnmanager]: https://github.com/citizenfx/cfx-server-data/tree/master/resources/%5Bmanagers%5D/spawnmanager
[EssentialMode]: https://github.com/kanersps/essentialmode