### PR TITLE
feature, fixes (client) - default pickup model config, unload models, duplicate functions and pickups

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -282,8 +282,8 @@ RegisterNetEvent('esx:removePickup')
 AddEventHandler('esx:removePickup', function(id)
 	if pickups[id] and pickups[id].object then
 		ESX.Game.DeleteObject(pickups[id].object)
-		if pickup.type == 'item_weapon' then
-			RemoveWeaponAsset(pickup.name)
+		if pickups[id].type == 'item_weapon' then
+			RemoveWeaponAsset(pickups[id].name)
 		else
 			SetModelAsNoLongerNeeded(Config.DefaultPickupModel)
 		end

--- a/client/main.lua
+++ b/client/main.lua
@@ -280,14 +280,15 @@ end)
 
 RegisterNetEvent('esx:removePickup')
 AddEventHandler('esx:removePickup', function(id)
-	if pickups[id] and pickups[id].object then
-		ESX.Game.DeleteObject(pickups[id].object)
-		if pickups[id].type == 'item_weapon' then
-			RemoveWeaponAsset(pickups[id].name)
+	local pickup = pickups[id]
+	if pickup and pickup.object then
+		ESX.Game.DeleteObject(pickup.object)
+		if pickup.type == 'item_weapon' then
+			RemoveWeaponAsset(pickup.name)
 		else
 			SetModelAsNoLongerNeeded(Config.DefaultPickupModel)
 		end
-		pickups[id] = nil
+		pickup = nil
 	end
 end)
 

--- a/client/main.lua
+++ b/client/main.lua
@@ -282,6 +282,11 @@ RegisterNetEvent('esx:removePickup')
 AddEventHandler('esx:removePickup', function(id)
 	if pickups[id] and pickups[id].object then
 		ESX.Game.DeleteObject(pickups[id].object)
+		if pickup.type == 'item_weapon' then
+			RemoveWeaponAsset(pickup.name)
+		else
+			SetModelAsNoLongerNeeded(Config.DefaultPickupModel)
+		end
 		pickups[id] = nil
 	end
 end)
@@ -412,7 +417,7 @@ CreateThread(function()
 							GiveWeaponComponentToWeaponObject(pickup.object, component.hash)
 						end
 					else
-						ESX.Game.SpawnLocalObject(`prop_money_bag_01`, pickup.coords, function(obj)
+						ESX.Game.SpawnLocalObject(Config.DefaultPickupModel, pickup.coords, function(obj)
 							pickup.object = obj
 						end)
 
@@ -429,6 +434,11 @@ CreateThread(function()
 			else
 				if DoesEntityExist(pickup.object) then
 					DeleteObject(pickup.object)
+					if pickup.type == 'item_weapon' then
+						RemoveWeaponAsset(pickup.name)
+					else
+						SetModelAsNoLongerNeeded(Config.DefaultPickupModel)
+					end
 				end
 			end
 			

--- a/config.lua
+++ b/config.lua
@@ -25,3 +25,5 @@ Config.PrimaryIdentifier	= "steam" -- Options: steam, license (social club), fiv
 -- then this will make them invisible until the actual outfit/model has loaded, this looks better than
 -- loading another model then changing it immediately after
 Config.DefaultPlayerModel	= `mp_m_freemode_01` 
+
+Config.DefaultPickupModel = `prop_money_bag_01`


### PR DESCRIPTION
- Made duped functions of spawning vehicles/props/pickups call the other function instead of having the same code called twice (with an extra param)
- Made pickups cull models when not within 50 units, I know the engine would do the main culling since they are just props, but the models are still "in memory" and if there are a high number of pickups within a certain radius it could affect performance
- Added a default pickup model config option
- On deleting of the prop remove the model or weapon asset from memory