### PR TITLE
fix (server) - adding permissions

### DIFF
--- a/server/classes/player.lua
+++ b/server/classes/player.lua
@@ -15,7 +15,7 @@ function CreateExtendedPlayer(playerId, identifier, group, accounts, inventory, 
 	self.weight = weight
 	self.maxWeight = Config.MaxWeight
 
-	ExecuteCommand(('add_principal identifier.steam:%s group.%s'):format(self.identifier, self.group))
+	ExecuteCommand(('add_principal identifier.%s group.%s'):format(self.identifier, self.group))
 
 	self.triggerEvent = function(eventName, ...)
 		TriggerClientEvent(eventName, self.source, ...)


### PR DESCRIPTION
- Fixed an issue where "steam:" was being included in the "add_principal" function on a new character. The identifier already includes "steam:" so it was not needed