### PR TITLE
fix: insanely large player objects

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -126,13 +126,32 @@ AddEventHandler('esx:setAccountMoney', function(account)
 end)
 
 RegisterNetEvent('esx:addInventoryItem')
-AddEventHandler('esx:addInventoryItem', function(item, count, showNotification)
+AddEventHandler('esx:addInventoryItem', function(item, count, showNotification, newItem)
+	local found = false
+
 	for k,v in ipairs(ESX.PlayerData.inventory) do
 		if v.name == item then
 			ESX.UI.ShowInventoryItemNotification(true, v.label, count - v.count)
 			ESX.PlayerData.inventory[k].count = count
+
+			found = true
 			break
 		end
+	end
+
+	if(found == false)then
+		ESX.PlayerData.inventory[#ESX.PlayerData.inventory + 1] = {
+			name = newItem.name,
+			count = count,
+			label = newItem.label,
+			weight = newItem.weight,
+			limit = newItem.limit,
+			usable = newItem.usable,
+			rare = newItem.rare,
+			canRemove = newItem.canRemove
+		}
+
+		ESX.UI.ShowInventoryItemNotification(true, newItem.label, 1)
 	end
 
 	if showNotification then

--- a/server/classes/player.lua
+++ b/server/classes/player.lua
@@ -93,7 +93,7 @@ function CreateExtendedPlayer(playerId, identifier, group, accounts, inventory, 
 
 	self.set = function(k, v, recursion)
 		if(not recursion)then
-			TriggerEvent("es:getPlayerFromId", self.source, function(user) user.set(k, v) end)
+			TriggerEvent("es:getPlayerFromId", self.source, function(user) if(user)then user.set(k, v) end end)
 		end
 
 		self.variables[k] = v
@@ -223,10 +223,33 @@ function CreateExtendedPlayer(playerId, identifier, group, accounts, inventory, 
 	end
 
 	self.getInventoryItem = function(name)
+		local found = false
+		local newItem
+
 		for k,v in ipairs(self.inventory) do
 			if v.name == name then
+				found = true
 				return v
 			end
+		end
+
+		local item = ESX.Items[name]
+
+		if(item)then
+			newItem = {
+				name = name,
+				count = 0,
+				label = item.label,
+				weight = item.weight,
+				limit = item.limit,
+				usable = ESX.UsableItemsCallbacks[name] ~= nil,
+				rare = item.rare,
+				canRemove = item.canRemove
+			}
+
+			table.insert(self.inventory, newItem)
+
+			return newItem
 		end
 
 		return
@@ -241,7 +264,7 @@ function CreateExtendedPlayer(playerId, identifier, group, accounts, inventory, 
 			self.weight = self.weight + (item.weight * count)
 
 			TriggerEvent('esx:onAddInventoryItem', self.source, item.name, item.count)
-			self.triggerEvent('esx:addInventoryItem', item.name, item.count)
+			self.triggerEvent('esx:addInventoryItem', item.name, item.count, false, item)
 		end
 	end
 

--- a/server/main.lua
+++ b/server/main.lua
@@ -152,16 +152,18 @@ function loadESXPlayer(identifier, playerId)
 				local count = foundItems[name] or 0
 				if count > 0 then userData.weight = userData.weight + (item.weight * count) end
 
-				table.insert(userData.inventory, {
-					name = name,
-					count = count,
-					label = item.label,
-					weight = item.weight,
-					limit = item.limit,
-					usable = ESX.UsableItemsCallbacks[name] ~= nil,
-					rare = item.rare,
-					canRemove = item.canRemove
-				})
+				if(count > 0)then
+					table.insert(userData.inventory, {
+						name = name,
+						count = count,
+						label = item.label,
+						weight = item.weight,
+						limit = item.limit,
+						usable = ESX.UsableItemsCallbacks[name] ~= nil,
+						rare = item.rare,
+						canRemove = item.canRemove
+					})
+				end
 			end
 
 			table.sort(userData.inventory, function(a, b)


### PR DESCRIPTION
Part I of a series of incoming fixes to the core of the player object.

This fixes the following:
- MissingBytes error in console (unless a player inventory is massive >100)
- Players unable to pickup new items unless they already had it