### PR TITLE
tweak: improve the way ExM uses the mysql-async library and database

### DIFF
--- a/server/common.lua
+++ b/server/common.lua
@@ -40,44 +40,118 @@ exports("getExtendedModeObject", function()
 	return ExM
 end)
 
+ExM.DatabaseReady = false
+ExM.DatabaseType = nil
+
+print('[ExtendedMode] [^2INFO^7] Starting up...')
+
 MySQL.ready(function()
-	MySQL.Async.fetchAll('SELECT * FROM items', {}, function(result)
-		for k,v in ipairs(result) do
-			ESX.Items[v.name] = {
-				label = v.label,
-				weight = v.weight,
-				rare = v.rare,
-				limit = v.limit,
-				canRemove = v.can_remove
-			}
-		end
-	end)
+	print('[ExtendedMode] [^2INFO^7] Checking your database...')
+	
+	-- Check the information schema for the tables that match the esx ones
+	MySQL.Async.fetchAll("SELECT TABLE_NAME AS 't', COLUMN_NAME AS 'c' FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_NAME = 'users' or TABLE_NAME = 'user_inventory' or TABLE_NAME = 'user_accounts'", {}, function(informationSchemaResult)
+		local databaseCheckFunction = function()
+			-- Ensure we have a result that we can iterate
+			if type(informationSchemaResult) ~= "table" then
+				print('[ExtendedMode] [^1ERROR^7] Your database is not compatible with ExtendedMode!\nIf this is a fresh installation, you may have forgotten to import the SQL template.')
+				error()
+			end
 
-	MySQL.Async.fetchAll('SELECT * FROM jobs', {}, function(jobs)
-		for k,v in ipairs(jobs) do
-			ESX.Jobs[v.name] = v
-			ESX.Jobs[v.name].grades = {}
-		end
+			-- Coagulate table columns from results
+			local tableMatchings = {}
+			for _, data in ipairs(informationSchemaResult) do
+				tableMatchings[data.t] = tableMatchings[data.t] or {}
+				tableMatchings[data.t][data.c] = true
+			end
 
-		MySQL.Async.fetchAll('SELECT * FROM job_grades', {}, function(jobGrades)
-			for k,v in ipairs(jobGrades) do
-				if ESX.Jobs[v.job_name] then
-					ESX.Jobs[v.job_name].grades[tostring(v.grade)] = v
+			-- Check for invalid scenarios
+			if not tableMatchings["users"] then
+				print("[ExtendedMode] [^1ERROR^7] Your database is not compatible with ExtendedMode!\nYou do not have a users table. Please import the SQL template found in the resource directory.")
+				error()
+			else
+				if tableMatchings["users"]["inventory"] and tableMatchings["users"]["accounts"] then
+					ExM.DatabaseType = "newesx"
+				elseif tableMatchings["user_inventory"] and tableMatchings["user_accounts"] then
+					ExM.DatabaseType = "es+esx"
 				else
-					print(('[ExtendedMode] [^3WARNING^7] Ignoring job grades for "%s" due to missing job'):format(v.job_name))
+					print("[ExtendedMode] [^1ERROR^7] Your database is not compatible with ExtendedMode!\nYou do not have anywhere for either the inventory or account info to be stored.\nRe-importing the SQL template may fix this!")
+					error()
 				end
 			end
 
-			for k2,v2 in pairs(ESX.Jobs) do
-				if ESX.Table.SizeOf(v2.grades) == 0 then
-					ESX.Jobs[v2.name] = nil
-					print(('[ExtendedMode] [^3WARNING^7] Ignoring job "%s" due to no job grades found'):format(v2.name))
+			-- Do some other database type validation... (this is temporary!)
+			if ExM.DatabaseType then
+				if ExM.DatabaseType == "es+esx" then
+					print("[ExtendedMode] [^1ERROR^7] Your database is using the 'es+esx' storage format.\nThis version of ExtendedMode is not yet fully compatible with that storage format.\nWe are currently working on full backwards compatibility on the 'esx-1.1-compat' branch if you would like to try it out.")
+					error()
+				elseif ExM.DatabaseType == "newesx" then -- redundant check as there are no other database types but oh well, future proofing I guess
+					print(("[ExtendedMode] [^2INFO^7] Your database is using the '%s' storage format, starting..."):format(ExM.DatabaseType))
+				else
+					print(("[ExtendedMode] [^2INFO^7] Your database is using the '%s' storage format, this is ^1not^7 compatible with ExtendedMode!"):format(ExM.DatabaseType))
+					error()
+				end
+			else
+				print("[ExtendedMode] [^1ERROR^7] An unknown error occured while determining your database storage format!")
+				error()
+			end
+		end
+
+		if pcall(databaseCheckFunction) then
+			MySQL.Async.fetchAll('SELECT * FROM items', {}, function(result)
+				for k,v in ipairs(result) do
+					ESX.Items[v.name] = {
+						label = v.label,
+						weight = v.weight,
+						rare = v.rare,
+						limit = v.limit,
+						canRemove = v.can_remove
+					}
+				end
+			end)
+		
+			MySQL.Async.fetchAll('SELECT * FROM jobs', {}, function(jobs)
+				for k,v in ipairs(jobs) do
+					ESX.Jobs[v.name] = v
+					ESX.Jobs[v.name].grades = {}
+				end
+		
+				MySQL.Async.fetchAll('SELECT * FROM job_grades', {}, function(jobGrades)
+					for k,v in ipairs(jobGrades) do
+						if ESX.Jobs[v.job_name] then
+							ESX.Jobs[v.job_name].grades[tostring(v.grade)] = v
+						else
+							print(('[ExtendedMode] [^3WARNING^7] Ignoring job grades for "%s" due to missing job'):format(v.job_name))
+						end
+					end
+		
+					for k2,v2 in pairs(ESX.Jobs) do
+						if ESX.Table.SizeOf(v2.grades) == 0 then
+							ESX.Jobs[v2.name] = nil
+							print(('[ExtendedMode] [^3WARNING^7] Ignoring job "%s" due to no job grades found'):format(v2.name))
+						end
+					end
+				end)
+			end)
+	
+			-- Wait for the db sync function to be ready incase it isn't ready yet somehow.
+			if not ESX.StartDBSync or not ESX.StartPayCheck then
+				print('[ExtendedMode] [^2INFO^7] ExtendedMode has been initialized')
+				while not ESX.StartDBSync and not ESX.StartPayCheck do
+					Wait(1000)
 				end
 			end
-		end)
+	
+			ExM.DatabaseReady = true
+	
+			-- Start DBSync and the paycheck
+			ESX.StartDBSync()
+			ESX.StartPayCheck()
+	
+			print('[ExtendedMode] [^2INFO^7] ExtendedMode has been initialized')
+		else
+			print('[ExtendedMode] [^1ERROR^7] ExtendedMode was unable to intialise the database and cannot continue, please see above for more information.')
+		end
 	end)
-
-	print('[ExtendedMode] [^2INFO^7] ExtendedMode has been initialized')
 end)
 
 RegisterServerEvent('esx:clientLog')

--- a/server/functions.lua
+++ b/server/functions.lua
@@ -164,7 +164,9 @@ ESX.TriggerServerCallback = function(name, requestId, source, cb, ...)
 end
 
 ESX.SavePlayer = function(xPlayer, cb)
-	MySQL.ready(function()
+	if ExM.DatabaseType == "es+esx" then
+		-- Nothing yet ;)
+	elseif ExM.DatabaseType == "newesx" then
 		MySQL.Async.execute('UPDATE users SET accounts = @accounts, job = @job, job_grade = @job_grade, `group` = @group, loadout = @loadout, position = @position, inventory = @inventory WHERE identifier = @identifier', {
 			['@accounts'] = json.encode(xPlayer.getAccounts(true)),
 			['@job'] = xPlayer.job.name,
@@ -175,7 +177,7 @@ ESX.SavePlayer = function(xPlayer, cb)
 			['@identifier'] = xPlayer.getIdentifier(),
 			['@inventory'] = json.encode(xPlayer.getInventory(true))
 		}, cb)
-	end)
+	end
 end
 
 ESX.SavePlayers = function(cb)


### PR DESCRIPTION
- Fix database access methods
- Remove overuse of the MySQL.ready callback
- Add database format detection, laying down a framework to support multiple database formats in the future

Historically, MySQL.ready was rarely used and could have resulted in errors in accessing the database if MySQL was not initialised when a player joined. Later on, all calls to MySQL functions were wrapped within a `MySQL.ready` callback to eliminate the chance for errors to occur and this worked fine until it was used in the player saving code after Async was dropped as a dependency and after transactions proved to be unstable. If called many times during the same server *tick*, `MySQL.ready` can cause server hitches.

This commit fixes this by having all functions piggyback off of a single callback with the new `ExM.DatabaseReady` boolean. Acompanioning this is the addition of database checks which run when ExtendedMode starts and ensures that ExtendedMode will work with the connected database. This lays the groundwork for multiple database formats to be supported however, as the details of multi-format database access and a possible complete redesign of the database.