### PR TITLE
changes (client) - change the way pickups work

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -290,7 +290,7 @@ end)
 RegisterNetEvent('esx:createMissingPickups')
 AddEventHandler('esx:createMissingPickups', function(missingPickups)
 	for pickupId, pickup in pairs(missingPickups) do
-		AddPickup(pickupId, pickup.label, vect(pickup.coords.x, pickup.coords.y, pickup.coords.z), pickup.type, pickup.name, pickup.components, pickup.tintIndex)
+		AddPickup(pickupId, pickup.label, vec(pickup.coords.x, pickup.coords.y, pickup.coords.z), pickup.type, pickup.name, pickup.components, pickup.tintIndex)
 	end
 end)
 
@@ -444,6 +444,16 @@ CreateThread(function()
 								local component = ESX.GetWeaponComponent(pickup.name, comp)
 								GiveWeaponComponentToWeaponObject(pickup.object, component.hash)
 							end
+							
+							SetEntityAsMissionEntity(pickup.object, true, false)
+							PlaceObjectOnGroundProperly(pickup.object)
+							SetEntityRotation(pickup.object, 90.0, 0.0, 0.0)
+							local model = GetEntityModel(pickup.object)
+							local heightAbove = GetEntityHeightAboveGround(pickup.object)
+							local currentCoords = GetEntityCoords(pickup.object)
+							local modelDimensionMin, modelDimensionMax = GetModelDimensions(model)
+							local size = (modelDimensionMax.y - modelDimensionMin.y) / 2
+							SetEntityCoords(pickup.object, currentCoords.x, currentCoords.y, (currentCoords.z - heightAbove) + size)
 						else
 							ESX.Game.SpawnLocalObject(Config.DefaultPickupModel, pickup.coords, function(obj)
 								pickup.object = obj
@@ -452,10 +462,11 @@ CreateThread(function()
 							while not pickup.object do
 								Wait(10)
 							end
+							
+							SetEntityAsMissionEntity(pickup.object, true, false)
+							PlaceObjectOnGroundProperly(pickup.object)
 						end
 
-						SetEntityAsMissionEntity(pickup.object, true, false)
-						PlaceObjectOnGroundProperly(pickup.object)
 						FreezeEntityPosition(pickup.object, true)
 						SetEntityCollision(pickup.object, false, true)
 					end
@@ -490,10 +501,11 @@ CreateThread(function()
 							end
 						end
 
-						label = ('%s~n~%s'):format(label, _U('threw_pickup_prompt'))
+						label = ('%s~n~%s'):format(label, _U('standard_pickup_prompt'))
 					end
-
-					ESX.Game.Utils.DrawText3D(vec(pickup.coords.x, pickup.coords.y, pickup.coords.z + 0.25), label, 1.2, 1)
+					
+					local pickupCoords = GetEntityCoords(pickup.object)
+					ESX.Game.Utils.DrawText3D(vec(pickupCoords.x, pickupCoords.y, pickupCoords.z + 0.5), label, 1.2, 4)
 				elseif pickup.textRange then
 					pickup.textRange = false
 				end

--- a/locales/br.lua
+++ b/locales/br.lua
@@ -36,6 +36,7 @@ Locales['br'] = {
   ['threw_weapon_already'] = 'você já esta com essa arma',
   ['threw_cannot_pickup'] = 'você não pode pegar porque seu inventário está cheio!',
   ['threw_pickup_prompt'] = 'pressione ~y~E~s~ para pegar',
+  ['standard_pickup_prompt'] = '~y~E:~s~ Pickup',
 
   -- Key mapping
   ['keymap_showinventory'] = 'exibir inventario',

--- a/locales/cs.lua
+++ b/locales/cs.lua
@@ -35,7 +35,8 @@ Locales['cs'] = {
   ['threw_weapon_ammo'] = 'vyhodil jsi ~b~%s~s~ s ~o~%sx %s~s~',
   ['threw_weapon_already'] = 'jiz stejnou zbraan mas',
   ['threw_cannot_pickup'] = 'tohle nemuzes sebrat, protoze tvuj inventar je plny',
-  ['threw_pickup_prompt'] = 'stiskni ~y~E~s~ po zvednuti',
+  ['threw_pickup_prompt'] = '~y~E~s~ po zvednuti',
+  ['standard_pickup_prompt'] = '~y~E:~s~ Pickup',
 
   -- Key mapping
   ['keymap_showinventory'] = 'zobrazit inventar', 

--- a/locales/de.lua
+++ b/locales/de.lua
@@ -36,6 +36,7 @@ Locales['de'] = {
   ['threw_weapon_already'] = 'Du hast bereits diese Waffe',
   ['threw_cannot_pickup'] = 'Du kannst das nicht aufheben, da dein Inventar voll ist',
   ['threw_pickup_prompt'] = 'drücke ~y~E~s~ um aufzuheben',
+  ['standard_pickup_prompt'] = '~y~E:~s~ Pickup',
 
   -- Key mapping
   ['keymap_showinventory'] = 'inventar anzeigen',

--- a/locales/en.lua
+++ b/locales/en.lua
@@ -36,6 +36,7 @@ Locales['en'] = {
   ['threw_weapon_already'] = 'you already carry the same weapon',
   ['threw_cannot_pickup'] = 'you cannot pickup that because your inventory is full!',
   ['threw_pickup_prompt'] = 'press ~y~E~s~ to pickup',
+  ['standard_pickup_prompt'] = '~y~E:~s~ Pickup',
 
   -- Key mapping
   ['keymap_showinventory'] = 'show Inventory',

--- a/locales/fi.lua
+++ b/locales/fi.lua
@@ -36,6 +36,7 @@ Locales['fi'] = {
   ['threw_weapon_already'] = 'you already carry the same weapon',
   ['threw_cannot_pickup'] = 'you cannot pickup that because your inventory is full!',
   ['threw_pickup_prompt'] = 'press ~y~E~s~ to pickup',
+  ['standard_pickup_prompt'] = '~y~E:~s~ Pickup',
 
   -- Key mapping
   ['keymap_showinventory'] = 'show Inventory',

--- a/locales/fr.lua
+++ b/locales/fr.lua
@@ -36,6 +36,7 @@ Locales['fr'] = {
   ['threw_weapon_already'] = 'vous portez déjà cette arme',
   ['threw_cannot_pickup'] = 'vous ne pouvez pas ramasser ça votre inventaire est plein !',
   ['threw_pickup_prompt'] = 'appuyez sur ~y~E~s~ pour ramasser',
+  ['standard_pickup_prompt'] = '~y~E:~s~ Pickup',
 
   -- Key mapping
   ['keymap_showinventory'] = 'montrer l\'inventaire',

--- a/locales/pl.lua
+++ b/locales/pl.lua
@@ -36,6 +36,7 @@ Locales['pl'] = {
   ['threw_weapon_already'] = 'you already carry the same weapon',
   ['threw_cannot_pickup'] = 'you cannot pickup that because your inventory is full!',
   ['threw_pickup_prompt'] = 'press ~y~E~s~ to pickup',
+  ['standard_pickup_prompt'] = '~y~E:~s~ Pickup',
 
   -- Key mapping
   ['keymap_showinventory'] = 'show Inventory',

--- a/locales/sc.lua
+++ b/locales/sc.lua
@@ -36,6 +36,7 @@ Locales['sc'] = {
   ['threw_weapon_already'] = '你已经有同样的武器了',
   ['threw_cannot_pickup'] = '你不能再拿起那个了，因为你的库存已经满了',
   ['threw_pickup_prompt'] = '按 ~y~E~s~ 拿起',
+  ['standard_pickup_prompt'] = '~y~E:~s~ Pickup',
 
   -- Key mapping
   ['keymap_showinventory'] = '显示库存',

--- a/locales/sv.lua
+++ b/locales/sv.lua
@@ -36,6 +36,7 @@ Locales['sv'] = {
   ['threw_weapon_already'] = 'du har redan ett sådant vapen på dig',
   ['threw_cannot_pickup'] = 'du kan inte plocka upp det på grund av att det kommer ej få plats i ditt förråd!',
   ['threw_pickup_prompt'] = 'tryck ~y~E~s~ för att plocka upp',
+  ['standard_pickup_prompt'] = '~y~E:~s~ Pickup',
 
   -- Key mapping
   ['keymap_showinventory'] = 'öppna inventory',

--- a/locales/tc.lua
+++ b/locales/tc.lua
@@ -36,6 +36,7 @@ Locales['tc'] = {
   ['threw_weapon_already'] = '您已經有相同的武器了',
   ['threw_cannot_pickup'] = '您不能再撿起該物品，因為您的背包已經滿了',
   ['threw_pickup_prompt'] = '按下 ~y~E~s~ 撿起',
+  ['standard_pickup_prompt'] = '~y~E:~s~ Pickup',
 
   -- Key mapping
   ['keymap_showinventory'] = '顯示背包',

--- a/server/main.lua
+++ b/server/main.lua
@@ -396,7 +396,7 @@ AddEventHandler('esx:removeInventoryItem', function(type, itemName, itemCount)
 
 			if weaponObject.ammo and weapon.ammo > 0 then
 				local ammoLabel = weaponObject.ammo.label
-				pickupLabel = ('~y~%s~s~ [~g~%s~s~ %s]'):format(weapon.label, weapon.ammo, ammoLabel)
+				pickupLabel = ('~y~%s~s~ [~g~%s~s~]'):format(weapon.label, weapon.ammo)
 				xPlayer.showNotification(_U('threw_weapon_ammo', weapon.label, weapon.ammo, ammoLabel))
 			else
 				pickupLabel = ('~y~%s~s~'):format(weapon.label)


### PR DESCRIPTION
- Made gun pickups lay on the ground now instead of standing upright
- Removed the word after ammo amount from appearing in pickup text since it's pretty self explanatory (rounds/rockets/etc.)
- Simplified label above pickups with just saying "E: Pickup" instead of "Press E to pickup", this is added with a new locale line, please if you speak any other languages correct this, currently just English in all files.
- Fixed a spelling error where I had "vect" instead of "vec" (Thanks to @editorzx for pointing that out)