### PR TITLE
fix (server) - pre 1.2 item.limit compatibility

### DIFF
--- a/server/classes/player.lua
+++ b/server/classes/player.lua
@@ -315,7 +315,15 @@ function CreateExtendedPlayer(playerId, identifier, group, accounts, inventory, 
 	self.canCarryItem = function(name, count)
 		local currentWeight, itemWeight = self.weight, ESX.Items[name].weight
 		local newWeight = currentWeight + (itemWeight * count)
-
+		local inventoryitem = self.getInventoryItem(name)
+		
+		if ESX.Items[name].limit ~= nil or ESX.Items[name].limit ~= -1 then
+			if count > ESX.Items[name].limit then
+				return false
+			elseif (inventoryitem.count + count) > ESX.Items[name].limit then
+				return false
+			end
+		end
 		return newWeight <= self.maxWeight
 	end
 


### PR DESCRIPTION
- function canCarryItem was only working for weight based systems completely ignoring the legacy limit column. This adds support for the limit column for pickups and other systems using the canCarryItem function

Also added a check for no limit and if they are using the limit column