### PR TITLE
tweak (server) - Switch to a cfg option for first spawn

### DIFF
--- a/config.lua
+++ b/config.lua
@@ -7,6 +7,8 @@ Config.Accounts = {
 	money = _U('account_money')
 }
 
+Config.FirstSpawnCoords = {x = -269.4, y = -955.3, z = 31.2, heading = 205.8}
+
 Config.StartingAccountMoney = {bank = 50000}
 
 Config.EnableSocietyPayouts = false -- pay from the society account that the player is employed at? Requirement: esx_society

--- a/extendedmode.sql
+++ b/extendedmode.sql
@@ -7,7 +7,7 @@ CREATE TABLE `users` (
 	`job` VARCHAR(20) NULL DEFAULT 'unemployed',
 	`job_grade` INT(11) NULL DEFAULT 0,
 	`loadout` LONGTEXT NULL DEFAULT NULL,
-	`position` VARCHAR(255) NULL DEFAULT '{"x":-269.4,"y":-955.3,"z":31.2,"heading":205.8}',
+	`position` VARCHAR(255) NULL DEFAULT NULL,
 
 	PRIMARY KEY (`identifier`)
 );

--- a/server/classes/player.lua
+++ b/server/classes/player.lua
@@ -315,7 +315,15 @@ function CreateExtendedPlayer(playerId, identifier, group, accounts, inventory, 
 	self.canCarryItem = function(name, count)
 		local currentWeight, itemWeight = self.weight, ESX.Items[name].weight
 		local newWeight = currentWeight + (itemWeight * count)
-
+		local inventoryitem = self.getInventoryItem(name)
+		
+		if ESX.Items[name].limit ~= nil or ESX.Items[name].limit ~= -1 then
+			if count > ESX.Items[name].limit then
+				return false
+			elseif (inventoryitem.count + count) > ESX.Items[name].limit then
+				return false
+			end
+		end
 		return newWeight <= self.maxWeight
 	end
 

--- a/server/main.lua
+++ b/server/main.lua
@@ -209,8 +209,7 @@ function loadESXPlayer(identifier, playerId)
 		if result[1].position and result[1].position ~= '' then
 			userData.coords = json.decode(result[1].position)
 		else
-			print('[ExtendedMode] [^3WARNING^7] Column "position" in "users" table is missing required default value. Using backup coords, fix your database.')
-			userData.coords = {x = -269.4, y = -955.3, z = 31.2, heading = 205.8}
+			userData.coords = Config.FirstSpawnCoords
 		end
 
 		-- Create Extended Player Object


### PR DESCRIPTION
Instead of having first spawn defined in the database default, just use a config option. Way more user friendly so they don't have to dig around the database for this.
