### PR TITLE
Switches or to and for player.canCarryItem condition

### DIFF
--- a/server/classes/player.lua
+++ b/server/classes/player.lua
@@ -317,7 +317,7 @@ function CreateExtendedPlayer(playerId, identifier, group, accounts, inventory, 
 		local newWeight = currentWeight + (itemWeight * count)
 		local inventoryitem = self.getInventoryItem(name)
 		
-		if ESX.Items[name].limit ~= nil or ESX.Items[name].limit ~= -1 then
+		if ESX.Items[name].limit ~= nil and ESX.Items[name].limit ~= -1 then
 			if count > ESX.Items[name].limit then
 				return false
 			elseif (inventoryitem.count + count) > ESX.Items[name].limit then


### PR DESCRIPTION
The current condition is always true, because `ESX.Items[name].limit` cannot be both `nil` and `-1`.
The error happens when `ESX.Items[name].limit` is `nil` : the second half of the condition will be true because `nil` != `-1`, and then it will error out on `if count > ESX.Items[name].limit then` because count is a number and `ESX.Items[name].limit` is `nil` => number vs nil comparison