### PR TITLE
fix/feature (client/server) - Infinity pickup support and global vars

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -279,12 +279,19 @@ function AddPickup(pickupId, pickupLabel, pickupCoords, pickupType, pickupName, 
 end
 
 RegisterNetEvent('esx:createPickup')
-AddEventHandler('esx:createPickup', function(pickupId, label, playerId, pickupType, name, components, tintIndex)
-	local playerPed = GetPlayerPed(GetPlayerFromServerId(playerId))
-	local entityCoords, forward = GetEntityCoords(playerPed), GetEntityForwardVector(playerPed)
-	local objectCoords = (entityCoords + forward * 1.0)
+AddEventHandler('esx:createPickup', function(pickupId, label, playerId, pickupType, name, components, tintIndex, isInfinity, pickupCoords)
+    local playerPed, entityCoords, forward, objectCoords
+    
+    if isInfinity then
+        objectCoords = pickupCoords
+    else
+        playerPed = GetPlayerPed(GetPlayerFromServerId(playerId))
+        entityCoords = GetEntityCoords(playerPed)
+        forward = GetEntityForwardVector(playerPed)
+        objectCoords = (entityCoords + forward * 1.0)
+    end
 
-	AddPickup(pickupId, label, objectCoords, pickupType, name, components, tintIndex)
+    AddPickup(pickupId, label, objectCoords, pickupType, name, components, tintIndex)
 end)
 
 RegisterNetEvent('esx:createMissingPickups')

--- a/server/common.lua
+++ b/server/common.lua
@@ -40,6 +40,10 @@ exports("getExtendedModeObject", function()
 	return ExM
 end)
 
+-- Globals to check if OneSync or Infinity for exclusive features
+ExM.IsOneSync = GetConvar('onesync_enabled', false) == 'true'
+ExM.IsInfinity = GetConvar('onesync_enableInfinity', false) == 'true'
+
 ExM.DatabaseReady = false
 ExM.DatabaseType = nil
 

--- a/server/functions.lua
+++ b/server/functions.lua
@@ -263,24 +263,29 @@ ESX.GetItemLabel = function(item)
 end
 
 ESX.CreatePickup = function(type, name, count, label, playerId, components, tintIndex)
-	local pickupId = (ESX.PickupId == 65635 and 0 or ESX.PickupId + 1)
-	local xPlayer = ESX.GetPlayerFromId(playerId)
+    local pickupId = (ESX.PickupId == 65635 and 0 or ESX.PickupId + 1)
+    local xPlayer = ESX.GetPlayerFromId(playerId)
+    local pedCoords
+    
+    if ExM.IsInfinity then
+        pedCoords = GetEntityCoords(GetPlayerPed(playerId))
+    end
 
-	ESX.Pickups[pickupId] = {
-		type  = type,
-		name  = name,
-		count = count,
-		label = label,
-		coords = xPlayer.getCoords(),
-	}
+    ESX.Pickups[pickupId] = {
+        type  = type,
+        name  = name,
+        count = count,
+        label = label,
+        coords = xPlayer.getCoords(),
+    }
 
-	if type == 'item_weapon' then
-		ESX.Pickups[pickupId].components = components
-		ESX.Pickups[pickupId].tintIndex = tintIndex
-	end
+    if type == 'item_weapon' then
+        ESX.Pickups[pickupId].components = components
+        ESX.Pickups[pickupId].tintIndex = tintIndex
+    end
 
-	TriggerClientEvent('esx:createPickup', -1, pickupId, label, playerId, type, name, components, tintIndex)
-	ESX.PickupId = pickupId
+    TriggerClientEvent('esx:createPickup', -1, pickupId, label, playerId, type, name, components, tintIndex, ExM.IsInfinity, pedCoords)
+    ESX.PickupId = pickupId
 end
 
 ESX.DoesJobExist = function(job, grade)


### PR DESCRIPTION
- Added 2 new global varibales for use in other scripts and ExM base. `ExM.IsOneSync` and `ExM.IsInfinity`. These can be used to make support for OneSync and Infinity modes
- Made pickups work on Infinity, previous it would error out on people outside of your bubble