### PR TITLE
Fix issues when removing some vehicle properties

### DIFF
--- a/client/functions.lua
+++ b/client/functions.lua
@@ -791,7 +791,7 @@ ESX.Game.SetVehicleProperties = function(vehicle, props)
 
 		if props.neonColor then SetVehicleNeonLightsColour(vehicle, props.neonColor[1], props.neonColor[2], props.neonColor[3]) end
 		if props.xenonColor then SetVehicleXenonLightsColour(vehicle, props.xenonColor) end
-		if props.modSmokeEnabled then ToggleVehicleMod(vehicle, 20, true) end
+		if props.modSmokeEnabled then ToggleVehicleMod(vehicle, 20, true) elseif props.modSmokeEnabled == false then ToggleVehicleMod(vehicle, 20, false) end
 		if props.tyreSmokeColor then SetVehicleTyreSmokeColor(vehicle, props.tyreSmokeColor[1], props.tyreSmokeColor[2], props.tyreSmokeColor[3]) end
 		if props.modSpoilers then SetVehicleMod(vehicle, 0, props.modSpoilers, false) end
 		if props.modFrontBumper then SetVehicleMod(vehicle, 1, props.modFrontBumper, false) end
@@ -810,8 +810,8 @@ ESX.Game.SetVehicleProperties = function(vehicle, props)
 		if props.modHorns then SetVehicleMod(vehicle, 14, props.modHorns, false) end
 		if props.modSuspension then SetVehicleMod(vehicle, 15, props.modSuspension, false) end
 		if props.modArmor then SetVehicleMod(vehicle, 16, props.modArmor, false) end
-		if props.modTurbo then ToggleVehicleMod(vehicle,  18, props.modTurbo) end
-		if props.modXenon then ToggleVehicleMod(vehicle,  22, props.modXenon) end
+		if props.modTurbo then ToggleVehicleMod(vehicle,  18, props.modTurbo) elseif props.modTurbo == false then ToggleVehicleMod(vehicle, 18, false) end
+		if props.modXenon then ToggleVehicleMod(vehicle,  22, props.modXenon) elseif props.modXenon == false then ToggleVehicleMod(vehicle, 22, false) end
 		if props.modFrontWheels then SetVehicleMod(vehicle, 23, props.modFrontWheels, false) end
 		if props.modBackWheels then SetVehicleMod(vehicle, 24, props.modBackWheels, false) end
 		if props.modPlateHolder then SetVehicleMod(vehicle, 25, props.modPlateHolder, false) end

--- a/client/main.lua
+++ b/client/main.lua
@@ -550,9 +550,6 @@ CreateThread(function()
 			playerHeading = ESX.Math.Round(GetEntityHeading(playerPed), 1)
 			formattedCoords = {x = ESX.Math.Round(playerCoords.x, 1), y = ESX.Math.Round(playerCoords.y, 1), z = ESX.Math.Round(playerCoords.z, 1), heading = playerHeading}
 			TriggerServerEvent('esx:updateCoords', formattedCoords)
-			if distance > 1 then
-				TriggerServerEvent('esx:updateCoords', formattedCoords)
-			end
 		end
 	end
 end)

--- a/client/main.lua
+++ b/client/main.lua
@@ -550,6 +550,9 @@ CreateThread(function()
 			playerHeading = ESX.Math.Round(GetEntityHeading(playerPed), 1)
 			formattedCoords = {x = ESX.Math.Round(playerCoords.x, 1), y = ESX.Math.Round(playerCoords.y, 1), z = ESX.Math.Round(playerCoords.z, 1), heading = playerHeading}
 			TriggerServerEvent('esx:updateCoords', formattedCoords)
+			if distance > 1 then
+				TriggerServerEvent('esx:updateCoords', formattedCoords)
+			end
 		end
 	end
 end)


### PR DESCRIPTION
There are some issues with esx_lscustom, when you hover on turbo or xenon (and I think smoke), they are applied but not removed, this fixed it for me. This should also work if you want to remove those properties from the vehicle.